### PR TITLE
MSVC/Win32 building with Premake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@ gfx/pokemon/*/frames.asm
 *.map
 *.sym
 
-# tool binaries
+# tool binaries and directories
 *.exe
+build/
 
 # precompiled python
 *.pyc
@@ -48,9 +49,12 @@ used_space.png
 # http://www.vim.org/scripts/script.php?script_id=441
 .lvimrc
 
-
-# vscode
+# vs + vscode
+.vs/
 .vscode/
+
+# dependencies
+deps/
 
 # swap files for vim and gedit
 .*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ used_space.png
 # http://www.vim.org/scripts/script.php?script_id=441
 .lvimrc
 
+
+# vscode
+.vscode/
+
 # swap files for vim and gedit
 .*.swp
 *~

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ RM	:= rm -f
 EXEOUT	:= -o
 EXTRA_CFLAGS := -std=c99 -Wall -Wextra -Wno-unused-label -Og -g3
 EXE	:= $(NAME)
+STATIC := yes
 
 TARGET := $(NAME)
 SRCS   := tools/emu/peanut_sdl.c tools/emu/minigb_apu/minigb_apu.c \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ in the root folder, run
 
 Then run suiCune to launch
 
+***For Visual Studio***
+
+- Download the latest SDL2 VC devel libraries
+- Extract SDL2 into `deps/` and rename the `SDL2-{version}` to just `SDL2`
+	- `deps/SDL2/`
+- Run `generate.bat` for Visual Studio 2022
+	- Edit `generate.bat` `vs2022` line to whatever you want
+	- All platforms and IDEs available [here](https://premake.github.io/docs/Using-Premake/)
+- Open the solution in the newly created `build` folder
+- Build
+- ???
+- Profit
+
 
 **Process (Beginning)**
 

--- a/audio/engine.h
+++ b/audio/engine.h
@@ -77,7 +77,7 @@ struct Channel {
     uint8_t field2e;
     uint8_t field2f;
     uint16_t field30;
-} __attribute__((packed));
+};
 
 void v_InitSound(void);
 void MusicFadeRestart(void);

--- a/constants/move_constants.h
+++ b/constants/move_constants.h
@@ -4,6 +4,11 @@
 // - MoveNames (see data/moves/names.asm)
 // - MoveDescriptions (see data/moves/descriptions.asm)
 // - BattleAnimations (see data/moves/animations.asm)
+
+#ifdef SING
+#undef SING
+#endif
+
 enum {
     NO_MOVE,      // 00
     POUND,        // 01

--- a/constants/move_constants.h
+++ b/constants/move_constants.h
@@ -5,8 +5,11 @@
 // - MoveDescriptions (see data/moves/descriptions.asm)
 // - BattleAnimations (see data/moves/animations.asm)
 
+//SING is a macro for _SING in Windows SDK
+#ifdef _WIN32
 #ifdef SING
 #undef SING
+#endif
 #endif
 
 enum {

--- a/engine/overworld/map_objects.c
+++ b/engine/overworld/map_objects.c
@@ -3656,4 +3656,5 @@ Addresses:
     // dw ['wObject10Struct'];
     // dw ['wObject11Struct'];
     // dw ['wObject12Struct'];
+    ;
 }

--- a/engine/overworld/map_objects.c
+++ b/engine/overworld/map_objects.c
@@ -3641,6 +3641,7 @@ GetObjectStructPointer:
     LD_B_hl;
     RET;
 
+/* Currently not used?
 Addresses:
 
     // dw ['wPlayerStruct'];
@@ -3656,5 +3657,5 @@ Addresses:
     // dw ['wObject10Struct'];
     // dw ['wObject11Struct'];
     // dw ['wObject12Struct'];
-    ;
+*/
 }

--- a/generate.bat
+++ b/generate.bat
@@ -1,0 +1,3 @@
+@echo off
+echo Generating project files...
+call "tools/premake5.exe" vs2022

--- a/home/hm_moves.c
+++ b/home/hm_moves.c
@@ -20,7 +20,7 @@ void IsHMMove(void){
     LD_DE(1);
     JP(mIsInArray);
 
-
+/* Currently not used?
 HMMoves:
         //db ['CUT'];
     //db ['FLY'];
@@ -30,5 +30,5 @@ HMMoves:
     //db ['WATERFALL'];
     //db ['WHIRLPOOL'];
     //db ['-1'];  // end
-    ;
+*/
 }

--- a/home/hm_moves.c
+++ b/home/hm_moves.c
@@ -30,5 +30,5 @@ HMMoves:
     //db ['WATERFALL'];
     //db ['WHIRLPOOL'];
     //db ['-1'];  // end
-
+    ;
 }

--- a/home/movement.c
+++ b/home/movement.c
@@ -145,5 +145,5 @@ MovementData:
     //big_step ['UP']
     //big_step ['LEFT']
     //big_step ['RIGHT']
-
+    ;
 }

--- a/home/movement.c
+++ b/home/movement.c
@@ -131,7 +131,7 @@ GetMovementData:
     POP_DE;
     RET;
 
-
+/* Currently not used?
 MovementData:
         //slow_step ['DOWN']
     //slow_step ['UP']
@@ -145,5 +145,5 @@ MovementData:
     //big_step ['UP']
     //big_step ['LEFT']
     //big_step ['RIGHT']
-    ;
+*/
 }

--- a/home/text.c
+++ b/home/text.c
@@ -1286,6 +1286,7 @@ void TextCommand_DAY(void) {
     POP_HL;
     RET;
 
+/*Currently not used?
 Days:
     // dw ['.Sun'];
     // dw ['.Mon'];
@@ -1318,5 +1319,5 @@ Satur:
 
 Day:
     //    db "DAY@"
-    ;
+*/
 }

--- a/home/text.c
+++ b/home/text.c
@@ -1318,4 +1318,5 @@ Satur:
 
 Day:
     //    db "DAY@"
+    ;
 }

--- a/home/vblank.c
+++ b/home/vblank.c
@@ -22,7 +22,7 @@ wait:
 }
 
 void VBlank(void) {
-        PUSH_AF;
+    PUSH_AF;
     PUSH_BC;
     PUSH_DE;
     PUSH_HL;

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,0 +1,68 @@
+workspace "suiCune"
+	location ".\\build\\"
+
+	targetdir "%{wks.location}\\bin\\%{cfg.buildcfg}\\"
+	objdir "%{wks.location}\\obj\\%{cfg.buildcfg}\\%{prj.name}\\"
+	buildlog "%{wks.location}\\obj\\%{cfg.buildcfg}\\%{prj.name}.log"
+
+	largeaddressaware "on"
+	editandcontinue "off"
+	staticruntime "on"
+
+	systemversion "latest"
+	characterset "unicode"
+	architecture "x86"
+	warnings "extra"
+
+	syslibdirs {
+        ".\\deps\\SDL2\\lib\\x86\\"
+	}
+
+	includedirs {
+		".\\src\\",
+        ".\\deps\\SDL2\\include\\"
+	}
+
+	platforms {
+		"x86",
+	}
+
+	configurations {
+		"Release",
+		"Debug",
+	}
+
+	filter "Release"
+		defines "NDEBUG"
+		optimize "debug"
+		runtime "debug"
+		symbols "on"
+
+	filter "Debug"
+		defines "DEBUG"
+		optimize "debug"
+		runtime "debug"
+		symbols "on"
+
+	project "suiCune"
+		targetname "suiCune"
+		language "c++"
+		kind "windowedapp"
+		warnings "off"
+
+		links {
+            "SDL2",
+            "SDL2main",
+		}
+		
+		files {
+			".\\tools\\emu\\peanut_sdl.c",
+			".\\tools\\emu\\minigb_apu\\minigb_apu.c",
+
+			".\\home\\*.c",
+			".\\audio\\*.c",
+            ".\\engine\\battle_anims\\*.c",
+            ".\\engine\\gfx\\*.c",
+            ".\\engine\\menus\\*.c",
+            ".\\engine\\overworld\\*.c",
+		}

--- a/premake5.lua
+++ b/premake5.lua
@@ -56,13 +56,6 @@ workspace "suiCune"
 		}
 		
 		files {
-			".\\tools\\emu\\peanut_sdl.c",
-			".\\tools\\emu\\minigb_apu\\minigb_apu.c",
-
-			".\\home\\*.c",
-			".\\audio\\*.c",
-            ".\\engine\\battle_anims\\*.c",
-            ".\\engine\\gfx\\*.c",
-            ".\\engine\\menus\\*.c",
-            ".\\engine\\overworld\\*.c",
+			".\\**.c",
+			".\\**.h",
 		}

--- a/tools/emu/peanut_sdl.c
+++ b/tools/emu/peanut_sdl.c
@@ -15,13 +15,15 @@
 #include <SDL.h>
 
 #include "minigb_apu/minigb_apu.h"
+#include "peanut_gb.h"
+#include "../../home/lcd.h"
+#include "rom_patches.h"
+
 struct gb_s gb;
 #define ROM_SIZE 0x200000
 void (*redirectFunc[ROM_SIZE])(void);
 void (*convertedFunc[ROM_SIZE])(void);
-#include "peanut_gb.h"
-#include "../../home/lcd.h"
-#include "rom_patches.h"
+
 struct priv_t {
     /* Pointer to allocated memory holding GB file. */
     uint8_t *rom;
@@ -2047,8 +2049,7 @@ void gb_run_frame(void) {
                     _RST(0x38);
                     break;  // RST
                 case 0xCB:  /* CB INST */
-                    uint8_t op = gb_read(gb.cpu_reg.pc++);
-                    switch (op) {
+                    switch (gb_read(gb.cpu_reg.pc++)) {
                         case 0x00:
                             RLC_B;
                             break;
@@ -3484,7 +3485,9 @@ void cleanup(void) {
     /* If the save file name was automatically generated (which required memory
      * allocated on the help), then free it here. */
     free(save_file_name);
+#ifndef _WIN32  //Crashes, not sure about other plats
     free(rom_file_name);
+#endif
 }
 
 int main(void) {

--- a/tools/emu/peanut_sdl.c
+++ b/tools/emu/peanut_sdl.c
@@ -3734,7 +3734,10 @@ out:
     /* If the save file name was automatically generated (which required memory
      * allocated on the help), then free it here. */
     free(save_file_name);
+
+#ifndef _WIN32  //Crashes
     free(rom_file_name);
+#endif
 
     return ret;
 }

--- a/tools/emu/peanut_sdl.c
+++ b/tools/emu/peanut_sdl.c
@@ -3490,7 +3490,7 @@ void cleanup(void) {
 #endif
 }
 
-int main(void) {
+int main(int argc, char* argv[]) {
     atexit(cleanup);
     enum gb_init_error_e gb_ret;
     int ret = EXIT_SUCCESS;


### PR DESCRIPTION
Could probably do SDL2 dep better than how I do it, I think premake has a package manager which I can look into for fixing later.

Removed gcc only `__attributes` and some of the labels broke the MSVC compile so I commented out the whole labels since they weren't used anyway.